### PR TITLE
Fix the case where there is no tagName and node_type != 3

### DIFF
--- a/js/demarcate.js
+++ b/js/demarcate.js
@@ -862,8 +862,17 @@
 				// get the tag name
 				var node = children[i];
 				var node_type = node.nodeType;
-				var tagName = node_type == 3 ? '_text' : node.tagName.toLowerCase();
 
+                		var tagName;
+
+                		if (node_type == 3) {
+                    			tagName = '_text';
+                		} else {
+                    			// No tag name, nothing to convert.
+                    			if(!node.tagName) continue;
+                    			tagName = node.tagName.toLowerCase();
+                		}
+                
 				// if this is not a plain text node perform ssome additional
 				// checks such as looking for a TOC, checking if our tag name
 				// is specified in the tagDict and if it is allowed to be 


### PR DESCRIPTION
This happens when you paste from Microsoft Word and get weird HTML (with inline XML, comments, etcetera).
Now PR on the right branch :smiley: 
